### PR TITLE
Short circuits and avoids calling db for isolation level in default case

### DIFF
--- a/guicey-jdbi3/src/main/java/ru/vyarus/guicey/jdbi3/tx/TransactionTemplate.java
+++ b/guicey-jdbi3/src/main/java/ru/vyarus/guicey/jdbi3/tx/TransactionTemplate.java
@@ -84,10 +84,12 @@ public class TransactionTemplate {
     private <T> T inCurrentTransaction(final TxConfig config, final TxAction<T> action) throws Exception {
         // mostly copies org.jdbi.v3.sqlobject.transaction.internal.TransactionDecorator logic
         final Handle h = manager.get();
-        final TransactionIsolationLevel currentLevel = h.getTransactionIsolationLevel();
-        if (config.isLevelSet() && currentLevel != config.getLevel()) {
-            throw new TransactionException("Tried to execute nested @Transaction(" + config.getLevel() + "), "
-                    + "but already running in a transaction with isolation level " + currentLevel + ".");
+        if (config.isLevelSet()) {
+            final TransactionIsolationLevel currentLevel = h.getTransactionIsolationLevel();
+            if (currentLevel != config.getLevel()) {
+                throw new TransactionException("Tried to execute nested @Transaction(" + config.getLevel() + "), "
+                        + "but already running in a transaction with isolation level " + currentLevel + ".");
+            }
         }
         if (h.isReadOnly() && !config.isReadOnly()) {
             throw new TransactionException("Tried to execute a nested @Transaction(readOnly=false) "


### PR DESCRIPTION
Alternative solution to issue discussed in #165 that avoids asking the underlying connection for the isolation level if it is not specified on the `@InTransaction` config.